### PR TITLE
Journalist can restrict premium articles for non-subscribers

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,3 @@
 {
-  "baseUrl": "http://localhost:3001"
+  "baseUrl": "http://localhost:3002"
 }

--- a/cypress/integration/userCanCreateArticle.feature.js
+++ b/cypress/integration/userCanCreateArticle.feature.js
@@ -15,6 +15,7 @@ describe("Journalist can", () => {
       cy.get(".title").type("Sweden vs Germany")
       cy.get(".teaser").type("The Corona crisis of Europe")
       cy.get(".content").type("Sweden should follow Germany's example during the Corona Crisis")
+      cy.get(".premium-article").select("Premium")
       cy.get("button").contains("Submit").click()
     });
     cy.get(".message").should("contain", "Your article is ready for review.")

--- a/cypress/integration/userCanCreateArticle.feature.js
+++ b/cypress/integration/userCanCreateArticle.feature.js
@@ -9,13 +9,24 @@ describe("Journalist can", () => {
     })
   });
 
-  it("write in its article", () => {
+  it("Create Premium article", () => {
     cy.get("button").contains("Create Article").click()
     cy.get(".create-article").within(() => {
       cy.get(".title").type("Sweden vs Germany")
       cy.get(".teaser").type("The Corona crisis of Europe")
       cy.get(".content").type("Sweden should follow Germany's example during the Corona Crisis")
-      cy.get('#premium').check()
+      cy.get('#premium').check({ force: true })
+      cy.get("button").contains("Submit").click()
+    });
+    cy.get(".message").should("contain", "Your article is ready for review.")
+  });
+
+  it("Create Free Article", () => {
+    cy.get("button").contains("Create Article").click()
+    cy.get(".create-article").within(() => {
+      cy.get(".title").type("Sweden vs Germany")
+      cy.get(".teaser").type("The Corona crisis of Europe")
+      cy.get(".content").type("Sweden should follow Germany's example during the Corona Crisis")
       cy.get("button").contains("Submit").click()
     });
     cy.get(".message").should("contain", "Your article is ready for review.")

--- a/cypress/integration/userCanCreateArticle.feature.js
+++ b/cypress/integration/userCanCreateArticle.feature.js
@@ -15,7 +15,7 @@ describe("Journalist can", () => {
       cy.get(".title").type("Sweden vs Germany")
       cy.get(".teaser").type("The Corona crisis of Europe")
       cy.get(".content").type("Sweden should follow Germany's example during the Corona Crisis")
-      cy.get(".premium-article").select("Premium")
+      cy.get('#premium').check()
       cy.get("button").contains("Submit").click()
     });
     cy.get(".message").should("contain", "Your article is ready for review.")

--- a/src/components/CreateArticle.jsx
+++ b/src/components/CreateArticle.jsx
@@ -1,79 +1,89 @@
-import React, { Component } from 'react'
-import { connect } from 'react-redux'
-import { TextArea, TextInput, Button, Form, Box, RadioButtonGroup } from 'grommet'
-import axios from 'axios'
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import {
+  TextArea,
+  TextInput,
+  Button,
+  Form,
+  Box,
+  CheckBox
+} from "grommet";
+import axios from "axios";
 
 class CreateArticle extends Component {
-
   articleCreation = async event => {
-    let isPremium;
-    if (event.target.access.value === "Premium") {
-      isPremium = false
+    let articleClass;
+    if (event.target.premium.checked === true) {
+      articleClass = "premium";
+    } else {
+      articleClass = "free";
     }
-    else if (event.target.access.value === "Free") {
-      isPremium = false
-    }
-    debugger
-    
+
     try {
-      let response = await axios.post('/articles', {
+      let response = await axios.post("/articles", {
         article: {
           title: event.target.title.value,
           teaser: event.target.teaser.value,
           content: event.target.content.value,
-          premium_article: isPremium
+          article_class: articleClass
         }
-      })
+
+      });
       debugger
       this.props.dispatch({
         type: "ARTICLE_SUBMITTED",
-        payload: { message: response.data.message }})
+        payload: { message: response.data.message }
+      });
     } catch (error) {
-      this.props.dispatch({type: "ARTICLE_SUBMITTED", payload: {message: error.message}})
-      debugger
+      this.props.dispatch({
+        type: "ARTICLE_SUBMITTED",
+        payload: { message: error.message }
+      });
     }
-  }
+  };
 
-  render () {
+  render() {
     return (
       <>
         <h1>Let's create some magic...</h1>
-        <Form className='create-article' onSubmit={this.articleCreation}>
-          <RadioButtonGroup
-              name="access"
-              className="access"
-              id="access"
-              options={["Free", "Premium"]}
-            />
+        <Form className="create-article" onSubmit={this.articleCreation}>
+          <CheckBox
+            name="premium"
+            className="premium"
+            id="premium"
+            label="Premium?"
+          />
+
           <TextInput
-            className='title'
-            placeholder='This is where you write your title'
-            key='title'
-            id='title'
+            className="title"
+            placeholder="This is where you write your title"
+            key="title"
+            id="title"
             required={true}
           />
           <TextArea
-            className='teaser'
-            placeholder='This is where you write your teaser'
-            key='teaser'
-            id='teaser'
+            className="teaser"
+            placeholder="This is where you write your teaser"
+            key="teaser"
+            id="teaser"
             required={true}
           />
           <TextArea
-            className='content'
-            placeholder='This is where you write your content'
-            key='content'
-            id='content'
+            className="content"
+            placeholder="This is where you write your content"
+            key="content"
+            id="content"
             required={true}
           />
-          <Button label='Submit Article' type='submit' />
-          <Button label='Go Back' onClick={() => this.props.dispatch({ type: 'HIDE_CREATE' })} />
+          <Button label="Submit Article" type="submit" />
+          <Button
+            label="Go Back"
+            onClick={() => this.props.dispatch({ type: "HIDE_CREATE" })}
+          />
         </Form>
-        <Box className="message">
-        {this.props.message}
-        </Box>
+        <Box className="message">{this.props.message}</Box>
       </>
-    )
+    );
   }
 }
 
@@ -83,4 +93,4 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps)(CreateArticle)
+export default connect(mapStateToProps)(CreateArticle);

--- a/src/components/CreateArticle.jsx
+++ b/src/components/CreateArticle.jsx
@@ -1,24 +1,36 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { TextArea, TextInput, Button, Form, Box } from 'grommet'
+import { TextArea, TextInput, Button, Form, Box, RadioButtonGroup } from 'grommet'
 import axios from 'axios'
 
 class CreateArticle extends Component {
 
   articleCreation = async event => {
+    let isPremium;
+    if (event.target.access.value === "Premium") {
+      isPremium = false
+    }
+    else if (event.target.access.value === "Free") {
+      isPremium = false
+    }
+    debugger
+    
     try {
       let response = await axios.post('/articles', {
         article: {
           title: event.target.title.value,
           teaser: event.target.teaser.value,
-          content: event.target.content.value
+          content: event.target.content.value,
+          premium_article: isPremium
         }
       })
+      debugger
       this.props.dispatch({
         type: "ARTICLE_SUBMITTED",
         payload: { message: response.data.message }})
     } catch (error) {
       this.props.dispatch({type: "ARTICLE_SUBMITTED", payload: {message: error.message}})
+      debugger
     }
   }
 
@@ -27,6 +39,12 @@ class CreateArticle extends Component {
       <>
         <h1>Let's create some magic...</h1>
         <Form className='create-article' onSubmit={this.articleCreation}>
+          <RadioButtonGroup
+              name="access"
+              className="access"
+              id="access"
+              options={["Free", "Premium"]}
+            />
           <TextInput
             className='title'
             placeholder='This is where you write your title'

--- a/src/components/CreateArticle.jsx
+++ b/src/components/CreateArticle.jsx
@@ -29,7 +29,6 @@ class CreateArticle extends Component {
         }
 
       });
-      debugger
       this.props.dispatch({
         type: "ARTICLE_SUBMITTED",
         payload: { message: response.data.message }

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ import { Provider } from "react-redux";
 import configureStore from "./state/store/configureStore";
 import axios from "axios";
 
-// axios.defaults.baseURL = "http://localhost:3000/api/";
-axios.defaults.baseURL = "https://urban-living.herokuapp.com/api/";
+axios.defaults.baseURL = "http://localhost:3000/api/";
+// axios.defaults.baseURL = "https://urban-living.herokuapp.com/api/";
 
 const store = configureStore();
 window.store = store;

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ import { Provider } from "react-redux";
 import configureStore from "./state/store/configureStore";
 import axios from "axios";
 
-axios.defaults.baseURL = "http://localhost:3000/api/";
-// axios.defaults.baseURL = "https://urban-living.herokuapp.com/api/";
+// axios.defaults.baseURL = "http://localhost:3000/api/";
+axios.defaults.baseURL = "https://urban-living.herokuapp.com/api/";
 
 const store = configureStore();
 window.store = store;


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171811181)
```
As a journalist, 
In order to grant subscribers access to top content,
I would like to be able to restrict my articles to premium readers only
```
## Changes proposed in this pull request:
* Added functionality to set an article as "premium"
* Added test for premium and free articles

## What I have learned working on this feature:
* How to make a checkbox clickable in Cypress 
* Refreshed knowledge of using application state with Redux

## Screenshots
![image](https://user-images.githubusercontent.com/59605858/77660959-486cbb00-6f7a-11ea-85cf-debdef803097.png)
![image](https://user-images.githubusercontent.com/59605858/77660972-4dca0580-6f7a-11ea-9653-471b94306f00.png)